### PR TITLE
Push job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,7 +277,9 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: install mamba
         uses: mamba-org/provision-with-micromamba@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,4 +301,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MESSAGE: "added rendered: ({sha}) {msg}"
         # GITHUB_TOKEN permmissions cannot be changed for forks
-        continue-on-error: true
+        continue-on-error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,4 +301,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MESSAGE: "added rendered: ({sha}) {msg}"
         # GITHUB_TOKEN permmissions cannot be changed for forks
-        continue-on-error: false
+        continue-on-error: true


### PR DESCRIPTION
When trying to push the rendered content from the ci to the "rendered" branch we see the following error:
```
##[info] Pushing
To https://github.com/jupyter-xeus/xeus-cookiecutter.git
 ! [remote rejected] rendered -> rendered (refusing to allow a GitHub App to create or update workflow `.github/workflows/main.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/jupyter-xeus/xeus-cookiecutter.git'

Error: Process exited with code: 1:
To https://github.com/jupyter-xeus/xeus-cookiecutter.git
 ! [remote rejected] rendered -> rendered (refusing to allow a GitHub App to create or update workflow `.github/workflows/main.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/jupyter-xeus/xeus-cookiecutter.git'

    at ChildProcess.<anonymous> (/home/runner/work/_actions/s0/git-publish-subdir-action/develop/action/dist/index.js:11966:20)
    at ChildProcess.emit (node:events:390:[28](https://github.com/jupyter-xeus/xeus-cookiecutter/actions/runs/4002364121/jobs/6869575421#step:5:29))
    at maybeClose (node:internal/child_process:1064:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:[30](https://github.com/jupyter-xeus/xeus-cookiecutter/actions/runs/4002364121/jobs/6869575421#step:5:31)1:5)
   ```

This [stack-overflow-answer](https://stackoverflow.com/questions/66643917/refusing-to-allow-a-github-app-to-create-or-update-workflow) suggest to add the toke to the checkout part:

```
    steps:
      - uses: actions/checkout@v3
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
```

